### PR TITLE
chore: fix ts-smoosh, copy over typeArguments

### DIFF
--- a/modules/dev-tools/src/ts-smoosh/smoosh.js
+++ b/modules/dev-tools/src/ts-smoosh/smoosh.js
@@ -287,7 +287,7 @@ function cloneType(node) {
   return node.type && node.type.typeName
     ? // If the node has a name, we clone it. Referencing the type nodes from the
       // d.ts file directly seems to break code comments.
-      ts.factory.createTypeReferenceNode(node.type.typeName.escapedText)
+      ts.factory.createTypeReferenceNode(node.type.typeName.escapedText, node.type.typeArguments)
     : // this should be a built-in type (like `string`, `number`, etc.)
       node.type;
 }

--- a/modules/dev-tools/test/ts-smoosh/fixtures/05-arrow-funcs/f.d.ts
+++ b/modules/dev-tools/test/ts-smoosh/fixtures/05-arrow-funcs/f.d.ts
@@ -1,7 +1,8 @@
+import Action from 'redux-actions';
+
 export type State = {
   a: string;
 };
-export type Action = {
-  payload: string;
-};
-export declare function createMapUpdater(state: State, action: Action): State;
+export type Payload = string
+
+export declare function createMapUpdater(state: State, action: Action<Payload>): State;

--- a/modules/dev-tools/test/ts-smoosh/fixtures/05-arrow-funcs/f.ts
+++ b/modules/dev-tools/test/ts-smoosh/fixtures/05-arrow-funcs/f.ts
@@ -1,10 +1,9 @@
+import Action from 'redux-actions';
 export type State = {
   a: string
 };
-export type Action = {
-  payload: string
-};
+export type Payload = string;
 
-export const createMapUpdater = (state: State, action: Action): State => {
+export const createMapUpdater = (state: State, action: Action<Payload>): State => {
   return state;
 };


### PR DESCRIPTION
Originally added by @heshan0131 