### PR TITLE
fix: Fix error codes returned by ocular-test, ocular-lint, etc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [14, 16]
 
     steps:
       - uses: actions/checkout@v2.1.1

--- a/modules/dev-tools/scripts/bootstrap.js
+++ b/modules/dev-tools/scripts/bootstrap.js
@@ -3,5 +3,7 @@
 const shell = require('shelljs');
 const path = require('path');
 
-// Runs the bash script and forward the arguments
-shell.exec(`${path.resolve(__dirname, './bootstrap.sh')} ${process.argv.slice(2).join(' ')}`);
+// Runs the bash script and forward the arguments, exiting with the same code
+shell.exit(
+  shell.exec(`${path.resolve(__dirname, './bootstrap.sh')} ${process.argv.slice(2).join(' ')}`).code
+);

--- a/modules/dev-tools/scripts/build.js
+++ b/modules/dev-tools/scripts/build.js
@@ -3,5 +3,7 @@
 const shell = require('shelljs');
 const path = require('path');
 
-// Runs the bash script and forward the arguments
-shell.exec(`${path.resolve(__dirname, './build.sh')} ${process.argv.slice(2).join(' ')}`);
+// Runs the bash script and forward the arguments, exiting with the same code
+shell.exit(
+  shell.exec(`${path.resolve(__dirname, './build.sh')} ${process.argv.slice(2).join(' ')}`).code
+);

--- a/modules/dev-tools/scripts/clean.js
+++ b/modules/dev-tools/scripts/clean.js
@@ -3,5 +3,7 @@
 const shell = require('shelljs');
 const path = require('path');
 
-// Runs the bash script and forward the arguments
-shell.exec(`${path.resolve(__dirname, './clean.sh')} ${process.argv.slice(2).join(' ')}`);
+// Runs the bash script and forward the arguments, exiting with the same code
+shell.exit(
+  shell.exec(`${path.resolve(__dirname, './clean.sh')} ${process.argv.slice(2).join(' ')}`).code
+);

--- a/modules/dev-tools/scripts/lint.js
+++ b/modules/dev-tools/scripts/lint.js
@@ -3,5 +3,7 @@
 const shell = require('shelljs');
 const path = require('path');
 
-// Runs the bash script and forward the arguments
-shell.exec(`${path.resolve(__dirname, './lint.sh')} ${process.argv.slice(2).join(' ')}`);
+// Runs the bash script and forward the arguments, exiting with the same code
+shell.exit(
+  shell.exec(`${path.resolve(__dirname, './lint.sh')} ${process.argv.slice(2).join(' ')}`).code
+);

--- a/modules/dev-tools/scripts/metrics.js
+++ b/modules/dev-tools/scripts/metrics.js
@@ -3,5 +3,7 @@
 const shell = require('shelljs');
 const path = require('path');
 
-// Runs the bash script and forward the arguments
-shell.exec(`${path.resolve(__dirname, './metrics.sh')} ${process.argv.slice(2).join(' ')}`);
+// Runs the bash script and forward the arguments, exiting with the same code
+shell.exit(
+  shell.exec(`${path.resolve(__dirname, './metrics.sh')} ${process.argv.slice(2).join(' ')}`).code
+);

--- a/modules/dev-tools/scripts/publish.js
+++ b/modules/dev-tools/scripts/publish.js
@@ -3,5 +3,7 @@
 const shell = require('shelljs');
 const path = require('path');
 
-// Runs the bash script and forward the arguments
-shell.exec(`${path.resolve(__dirname, './publish.sh')} ${process.argv.slice(2).join(' ')}`);
+// Runs the bash script and forward the arguments, exiting with the same code
+shell.exit(
+  shell.exec(`${path.resolve(__dirname, './publish.sh')} ${process.argv.slice(2).join(' ')}`).code
+);

--- a/modules/dev-tools/scripts/test.js
+++ b/modules/dev-tools/scripts/test.js
@@ -3,5 +3,7 @@
 const shell = require('shelljs');
 const path = require('path');
 
-// Runs the bash script and forward the arguments
-shell.exec(`${path.resolve(__dirname, './test.sh')} ${process.argv.slice(2).join(' ')}`);
+// Runs the bash script and forward the arguments, exiting with the same code
+shell.exit(
+  shell.exec(`${path.resolve(__dirname, './test.sh')} ${process.argv.slice(2).join(' ')}`).code
+);


### PR DESCRIPTION
The indirection introduced in #6 doesn't propagate the error code for script failures, effectively kneecapping our tests and lint. This updates to immediately exit, propagating the error code, after the bash script runs.