### PR TITLE
chore: Bump coverage memory limit

### DIFF
--- a/modules/dev-tools/scripts/test.sh
+++ b/modules/dev-tools/scripts/test.sh
@@ -55,7 +55,7 @@ case $MODE in
     ;;
 
   "cover")
-    (set -x; NODE_ENV=test BABEL_ENV=test npx nyc node $MODULE_DIR/node/test.js cover)
+    (set -x; NODE_ENV=test BABEL_ENV=test npx nyc node --max-old-space-size=4092 $MODULE_DIR/node/test.js cover)
     (set -x; npx nyc report --reporter=lcov)
     ;;
 


### PR DESCRIPTION
We ran into heap memory limits in [this PR](https://github.com/foursquare/unfolded-platform/pull/4325), and for some reason we can't specify this setting as an env variable when running the ocular script, but have to do it here instead