### PR TITLE
chore: Undo heap memory bump

### DIFF
--- a/modules/dev-tools/package.json
+++ b/modules/dev-tools/package.json
@@ -60,7 +60,7 @@
     "@typescript-eslint/eslint-plugin": "^4.26.1",
     "@typescript-eslint/parser": "^4.26.1",
     "babel-loader": "8.2.2",
-    "babel-plugin-istanbul": "^6.0.0",
+    "babel-plugin-istanbul": "^6.1.1",
     "babel-plugin-version-inline": "^1.0.0",
     "core-js": "^3.2.1",
     "coveralls": "^3.0.3",

--- a/modules/dev-tools/scripts/test.sh
+++ b/modules/dev-tools/scripts/test.sh
@@ -55,7 +55,7 @@ case $MODE in
     ;;
 
   "cover")
-    (set -x; NODE_ENV=test BABEL_ENV=test npx nyc node --max-old-space-size=4092 $MODULE_DIR/node/test.js cover)
+    (set -x; NODE_ENV=test BABEL_ENV=test npx nyc node $MODULE_DIR/node/test.js cover)
     (set -x; npx nyc report --reporter=lcov)
     ;;
 

--- a/modules/dev-tools/src/configuration/get-babel-config.js
+++ b/modules/dev-tools/src/configuration/get-babel-config.js
@@ -68,7 +68,7 @@ const ENV_CONFIG = {
         }
       ]
     ],
-    plugins: [...COMMON_PLUGINS]
+    plugins: [...COMMON_PLUGINS, 'istanbul']
   }
 };
 

--- a/modules/dev-tools/src/configuration/get-babel-config.js
+++ b/modules/dev-tools/src/configuration/get-babel-config.js
@@ -68,7 +68,7 @@ const ENV_CONFIG = {
         }
       ]
     ],
-    plugins: [...COMMON_PLUGINS, 'istanbul']
+    plugins: [...COMMON_PLUGINS]
   }
 };
 


### PR DESCRIPTION
Previous memory bump did not solve the issue after all, the problem seems to be with the istanbul babel plugin that gets activated when `BABEL_ENV` or `NODE_ENV` is set to `test`. It seems like the issue is fixed by disabling nyc sourcemaps and instruments that are handled elsewhere instead - https://github.com/foursquare/unfolded-platform/pull/4325/files#diff-ed87f441d2b6161076f7bbcc6e7f683648406048cb96177e0390c4c9943a6462R18